### PR TITLE
fix: channel now has data structure for invites

### DIFF
--- a/ft_irc/include/core/Channel.hpp
+++ b/ft_irc/include/core/Channel.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <set>
 
 class Client;
 
@@ -20,6 +21,7 @@ private:
 	std::string _key;
 	bool _hasUserLimit;
 	size_t _userLimit;
+	std::set<std::string> _invitedUsers;
 
 public:
 	Channel(const std::string& name);
@@ -66,6 +68,12 @@ public:
 
 	// Utility
 	bool isEmpty() const;
+
+	void addInvitedUser(const std::string& nickname);
+	void removeInvitedUser(const std::string& nickname);
+	bool isUserInvited(const std::string& nickname) const;
+	void clearInvitedUser(const std::string& nickname);
+	const std::set<std::string>& getInvitedUsers() const;
 };
 
 #endif

--- a/ft_irc/src/commands/channel/JoinCommand.cpp
+++ b/ft_irc/src/commands/channel/JoinCommand.cpp
@@ -99,7 +99,7 @@ void    JoinCommand::joinChannel(Client* client, const std::string& channelName,
 		else
 		{
 			{
-				if (channel->isInviteOnly())
+				if (channel->isInviteOnly() && !channel->isUserInvited(client->getNickname()))
 				{
 					Print::Warn("Channel is invite-only");
 					sendErrorReply(client, IRC::ERR_INVITEONLYCHAN, channel->getName() + " :Cannot join channel (+i)");
@@ -122,6 +122,7 @@ void    JoinCommand::joinChannel(Client* client, const std::string& channelName,
 				}
 			}
 			channel->addClient(client);
+			channel->removeInvitedUser(client->getNickname());
 			client->sendMessage(joinMessage);
 			_server->broadcastChannel(joinMessage, channel->getName(), client->getFd());
 		}

--- a/ft_irc/src/core/Channel.cpp
+++ b/ft_irc/src/core/Channel.cpp
@@ -165,3 +165,28 @@ void Channel::broadcast(const std::string& message, int excludeFd)
 		}
 	}
 }
+
+void Channel::addInvitedUser(const std::string& nickname)
+{
+    _invitedUsers.insert(nickname);
+}
+
+void Channel::removeInvitedUser(const std::string& nickname)
+{
+    _invitedUsers.erase(nickname);
+}
+
+bool Channel::isUserInvited(const std::string& nickname) const
+{
+    return _invitedUsers.find(nickname) != _invitedUsers.end();
+}
+
+void Channel::clearInvitedUser(const std::string& nickname)
+{
+    _invitedUsers.erase(nickname);
+}
+
+const std::set<std::string>& Channel::getInvitedUsers() const
+{
+    return _invitedUsers;
+}

--- a/ft_irc/src/core/Server.cpp
+++ b/ft_irc/src/core/Server.cpp
@@ -565,6 +565,21 @@ void Server::print_clients(bool command)
 			+ (it_channel->second->isTopicRestricted() ? " | Topic_Restricted" : "");
 		Print::Debug(ssa.str(), command);
 
+		const std::set<std::string>& invitedUsers = it_channel->second->getInvitedUsers();
+		if (!invitedUsers.empty())
+		{
+			std::stringstream inviteStream;
+			inviteStream << Color::VIOLET << "Invited nicknames: ";
+			for (std::set<std::string>::const_iterator invIt = invitedUsers.begin();
+			invIt != invitedUsers.end(); ++invIt)
+			{
+				if (invIt != invitedUsers.begin())
+					inviteStream << ", ";
+				inviteStream << *invIt;
+			}
+			Print::Debug(inviteStream.str(), command);
+		}
+
 		std::stringstream ssb;
 		ssb << std::right << Color::ORANGE << std::setw(10) << "FD" << "|" << std::setw(10) << "NICK"
 			<< "|" << std::setw(10) << "OPERATOR" << "|";


### PR DESCRIPTION
when nickname receives an invite, that invite is stored on channel std::set

before invited user joins to invited channel, we could see invites when print_data command

after user use that invite, join command auto-clear that invite.

when invited user leaves a channel, only could join, with a new invite